### PR TITLE
Support undefined props and private variants applied last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.2.0 (2022-11-14)
+
+### Changed
+
+- Prop values passed to `variant(s)` and `compoundVariant(s)` are now optional.
+  It allows to not apply default styles or having to create "empty variant" for default cases.
+
+- Private variants (prop starting by `_`) now overrides composed variants got from an existing variant declaration.
+
+  For example, let's consider a Button on which the "primary" variant define a white color, if a private variant is defining a different color, it's possible to override the primary color like this:
+
+```tsx
+<Button variant="primary" _color="red" />
+```
+
 ## v1.1.0 (2022-10-11)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ const Div = styled.div<Props>(props => {
 
     // The nice trick with `if` is that variants will be automatically "skipped"
     // from compound variants when being disabled.
-    // For example here, the color variant will not be applyed if used into
+    // For example here, the color variant will not be applied if used into
     // compoundVariant (see below).
     .if(
       false,
@@ -286,12 +286,12 @@ function ButtonComponent() {
   // the primary variant (blue) and in the first CSS block (white).
   background: 'silver',
 
-  // Get from the primary font variant, two variants applyed at the same time
+  // Get from the primary font variant, two variants applied at the same time
   fontWeight: 'bold',
   fontStyle: 'italic'
 
   // Get from the primary color variant
-  // (color:pink is not applyed because declared before the primary variant and
+  // (color:pink is not applied because declared before the primary variant and
   // no weight value has been set)
   color: 'white'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "build-variants",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-variants",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Build and manage styles variants for any libraries.",
   "author": "Alexis MINEAUD",
   "license": "MIT",

--- a/src/lib/BuildVariantsCSSMerger.ts
+++ b/src/lib/BuildVariantsCSSMerger.ts
@@ -18,6 +18,7 @@ export default class BuildVariantsCSSMerger<TCSSObject extends object> {
   ): this {
     const options: ObjectNonNullable<IBuildVariantsMergerCssPartsOptions> = {
       weight: 0,
+      _privateProp: false,
       ...options_
     }
 
@@ -51,15 +52,35 @@ export default class BuildVariantsCSSMerger<TCSSObject extends object> {
    */
 
   /**
-   * Deeply merge all CSS parts, optionally ordered by cssPart weight.
+   * Deeply merge all CSS parts, optionally ordered by weight or _privateProp.
    */
   private _merge(): TCSSObject {
-    const cssParts = Array.from(this._cssParts.values()).sort((a, b) => {
+    function sortByWeight(
+      a: IBuildVariantsMergerCssParts<TCSSObject>,
+      b: IBuildVariantsMergerCssParts<TCSSObject>
+    ) {
       // keep existing order if same weight
       if (a.options.weight === b.options.weight) {
         return 0
       }
+
       return a.options.weight > b.options.weight ? 1 : -1
+    }
+
+    function sortByPrivateProp(
+      a: IBuildVariantsMergerCssParts<TCSSObject>,
+      b: IBuildVariantsMergerCssParts<TCSSObject>
+    ) {
+      // keep existing order if same _privateProp
+      if (a.options._privateProp === b.options._privateProp) {
+        return 0
+      }
+
+      return a.options._privateProp > b.options._privateProp ? 1 : -1
+    }
+
+    const cssParts = Array.from(this._cssParts.values()).sort((a, b) => {
+      return sortByWeight(a, b) | sortByPrivateProp(a, b)
     })
 
     // deep merge all parts

--- a/src/tests/BuildVariantsBuilder.test.ts
+++ b/src/tests/BuildVariantsBuilder.test.ts
@@ -84,6 +84,32 @@ describe('BuildVariantsBuilder', () => {
   })
 
   describe('variant()', () => {
+    it('should not apply variant if the props value is undefined', () => {
+      interface IButtonProps {
+        type?: 'success' | 'error'
+      }
+
+      const props: IButtonProps = {}
+
+      const css = testBuildVariants(props)
+        .css({
+          color: 'white'
+        })
+        .variant('type', props.type, {
+          success: {
+            background: 'green'
+          },
+
+          error: {
+            background: 'red'
+          }
+        })
+        .end()
+
+      expect(css).toHaveProperty('color', 'white')
+      expect(css).not.toHaveProperty('background')
+    })
+
     it('should apply variant', () => {
       interface IButtonProps {
         type: 'default' | 'info' | 'success' | 'error'
@@ -132,6 +158,34 @@ describe('BuildVariantsBuilder', () => {
   })
 
   describe('variants()', () => {
+    it('should not apply variants if the props value is undefined', () => {
+      interface IButtonProps {
+        font?: Array<'strong' | 'underline' | 'italic'>
+      }
+
+      const props: IButtonProps = {}
+
+      const css = testBuildVariants(props)
+        .variants('font', props.font, {
+          strong: {
+            fontWeight: 'bold'
+          },
+
+          underline: {
+            textDecorationLine: 'underline'
+          },
+
+          italic: {
+            textDecoration: 'italic'
+          }
+        })
+        .end()
+
+      expect(css).not.toHaveProperty('fontWeight')
+      expect(css).not.toHaveProperty('textDecorationLine')
+      expect(css).not.toHaveProperty('textDecoration')
+    })
+
     it('should apply several variants', () => {
       interface IButtonProps {
         font: Array<'strong' | 'underline' | 'italic'>
@@ -220,6 +274,23 @@ describe('BuildVariantsBuilder', () => {
   })
 
   describe('compoundVariant()', () => {
+    it('should not apply if the props value is undefined', () => {
+      interface IButtonProps {
+        type?: 'success' | 'error'
+      }
+
+      const props: IButtonProps = {}
+
+      const css = testBuildVariants(props)
+        .compoundVariant('type', props.type, {
+          success: builder => builder.css({ color: 'green' }).end(),
+          error: builder => builder.css({ color: 'red' }).end()
+        })
+        .end()
+
+      expect(css).not.toHaveProperty('color')
+    })
+
     it('should compose variants from existing one', () => {
       interface IButtonProps {
         type?: 'default' | 'info' | 'success' | 'error'
@@ -378,6 +449,23 @@ describe('BuildVariantsBuilder', () => {
   })
 
   describe('compoundVariants()', () => {
+    it('should not apply if the props value is undefined', () => {
+      interface IButtonProps {
+        variants?: Array<'variant1' | 'variant2'>
+      }
+
+      const props: IButtonProps = {}
+
+      const css = testBuildVariants(props)
+        .compoundVariants('variants', props.variants, {
+          variant1: builder => builder.css({ color: 'blue' }).end(),
+          variant2: builder => builder.css({ color: 'red' }).end()
+        })
+        .end()
+
+      expect(css).not.toHaveProperty('color')
+    })
+
     it('should apply several compound variants', () => {
       interface IBoxProps {
         color?: 'unset' | 'red' | 'lime'
@@ -679,6 +767,74 @@ describe('BuildVariantsBuilder', () => {
         expect(css).toEqual({
           color: 'red'
         })
+      })
+    })
+  })
+
+  describe('With custom object shape', () => {
+    interface IAnimateObject {
+      rotate?: number
+      scale?: number
+      x?: number
+      y?: number
+    }
+
+    function testBuildVariantsForCustomShapes<
+      TProps extends LitteralObject,
+      TAnimateObject extends LitteralObject = IAnimateObject
+    >(props: TProps) {
+      return newBuildVariants<TProps, TAnimateObject>(props)
+    }
+
+    it('should apply values', () => {
+      interface IButtonAnimateProps {
+        _rotate?: 'left' | 'right'
+        _scale?: 'small' | 'big'
+        variant?: 'alert' | 'modal'
+      }
+
+      const props: IButtonAnimateProps = {
+        variant: 'alert'
+      }
+
+      const css = testBuildVariantsForCustomShapes(props)
+        .values({
+          rotate: 0,
+          scale: 0,
+          x: 0,
+          y: 0
+        })
+        .variant('_rotate', props._rotate, {
+          left: {
+            rotate: -90
+          },
+
+          right: {
+            rotate: 90
+          }
+        })
+        .variant('_scale', props._scale, {
+          small: {
+            scale: 25
+          },
+
+          big: {
+            scale: 50
+          }
+        })
+        .compoundVariant('variant', props.variant, {
+          alert: builder =>
+            builder.get('_rotate', 'left').get('_scale', 'big').end(),
+          modal: builder =>
+            builder.get('_rotate', 'right').get('_scale', 'small').end()
+        })
+        .end()
+
+      expect(css).toEqual({
+        rotate: -90,
+        scale: 50,
+        x: 0,
+        y: 0
       })
     })
   })

--- a/src/tests/BuildVariantsBuilder.test.ts
+++ b/src/tests/BuildVariantsBuilder.test.ts
@@ -155,6 +155,54 @@ describe('BuildVariantsBuilder', () => {
         textDecorationLine: 'underline'
       })
     })
+
+    describe('Private variants', () => {
+      it('should be applied last', () => {
+        interface ITextProps {
+          _color?: 'success' | 'error'
+          _weight?: 'lighter' | 'bolder'
+          variant?: 'success' | 'error'
+        }
+
+        const props: ITextProps = {
+          variant: 'success',
+          _color: 'error'
+        }
+
+        const css = testBuildVariants(props)
+          .variant('_color', props._color, {
+            success: {
+              color: 'green'
+            },
+
+            error: {
+              color: 'red'
+            }
+          })
+          .variant('_weight', props._weight, {
+            lighter: {
+              fontWeight: 'lighter'
+            },
+
+            bolder: {
+              fontWeight: 'bolder'
+            }
+          })
+          .compoundVariant('variant', props.variant, {
+            success: builder =>
+              builder.get('_color', 'success').get('_weight', 'lighter').end(),
+            error: builder =>
+              builder.get('_color', 'error').get('_weight', 'bolder').end()
+          })
+          .end()
+
+        expect(css).toEqual({
+          // should have color: red because of the private variant which overrides the compoundVariant's values
+          color: 'red',
+          fontWeight: 'lighter'
+        })
+      })
+    })
   })
 
   describe('variants()', () => {
@@ -772,6 +820,7 @@ describe('BuildVariantsBuilder', () => {
   })
 
   describe('With custom object shape', () => {
+    // This is no CSS! ... but it is working the same way!
     interface IAnimateObject {
       rotate?: number
       scale?: number

--- a/src/tests/BuildVariantsCSSMerger.test.ts
+++ b/src/tests/BuildVariantsCSSMerger.test.ts
@@ -10,7 +10,8 @@ describe('BuildVariantsCSSMerger', () => {
           color: 'red'
         },
         options: {
-          weight: 0
+          weight: 0,
+          _privateProp: false
         }
       },
       {
@@ -19,7 +20,8 @@ describe('BuildVariantsCSSMerger', () => {
           background: 'silver'
         },
         options: {
-          weight: 0
+          weight: 0,
+          _privateProp: false
         }
       }
     ]
@@ -43,7 +45,8 @@ describe('BuildVariantsCSSMerger', () => {
           color: 'red'
         },
         options: {
-          weight: 10
+          weight: 10,
+          _privateProp: false
         }
       },
       {
@@ -52,7 +55,43 @@ describe('BuildVariantsCSSMerger', () => {
           background: 'silver'
         },
         options: {
-          weight: 0
+          weight: 0,
+          _privateProp: false
+        }
+      }
+    ]
+
+    const cssMerger = new BuildVariantsCSSMerger()
+
+    cssParts.forEach(cssPart => {
+      cssMerger.add(cssPart.cssObject, cssPart.options)
+    })
+
+    expect(cssMerger.end()).toEqual({
+      color: 'red',
+      background: 'silver'
+    })
+  })
+
+  it('should merge CSS of private props last', () => {
+    const cssParts: Array<IBuildVariantsMergerCssParts<CSSObject>> = [
+      {
+        cssObject: {
+          color: 'red'
+        },
+        options: {
+          weight: 0,
+          _privateProp: true
+        }
+      },
+      {
+        cssObject: {
+          color: 'lime',
+          background: 'silver'
+        },
+        options: {
+          weight: 0,
+          _privateProp: false
         }
       }
     ]
@@ -80,7 +119,8 @@ describe('BuildVariantsCSSMerger', () => {
           border: '1px solid black'
         },
         options: {
-          weight: 0
+          weight: 0,
+          _privateProp: false
         }
       },
       {
@@ -90,7 +130,8 @@ describe('BuildVariantsCSSMerger', () => {
           }
         },
         options: {
-          weight: 0
+          weight: 0,
+          _privateProp: false
         }
       }
     ]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,7 +25,15 @@ export interface IBuildVariantsBuilderOptions<
 
 export interface IBuildVariantsMergerCssPartsOptions {
   weight?: number
+  // is provided by a private variant
+  _privateProp?: boolean
 }
+
+// Public IBuildVariantsMergerCssPartsOptions interface, without _privateProp option
+export type BuildVariantsMergerCssPartsOptionsPublic = Omit<
+  IBuildVariantsMergerCssPartsOptions,
+  '_privateProp'
+>
 
 export interface IBuildVariantsMergerCssParts<TCSSObject extends object> {
   cssObject: TCSSObject


### PR DESCRIPTION
## Description of the Change

- Prop values passed to `variant(s)` and `compoundVariant(s)` are now optional.
  It allows to not apply default styles or having to create "empty variant" for default cases.

- Private variants (prop starting by `_`) now overrides composed variants got from an existing variant declaration.

  For example, let's consider a Button on which the "primary" variant define a white color, if a private variant is defining a different color, it's possible to override the primary color like this:

```tsx
<Button variant="primary" _color="red" />
```

## Benefits

<!-- What benefits will be realized by the code change? -->

## Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

## Testing Instructions

<!-- What are the possible side-effects or negative impacts of the code change? -->

## Checklist

- [x] Tests added
